### PR TITLE
Improve build script and supported PostgreSQL versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.dll
 *.so
 *.dylib
+*.h
 
 # Test binary, build with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -5,7 +5,20 @@ Background Worker Processes for PostgreSQL written in Go
 
 ## Build
 
+1) Make sure the 'pg\_config' tool is in your $PATH, if not then config like the example below:
+
 ```
-go build -buildmode=c-shared -o prest.so
-cp prest.so /usr/lib/postgresql/9.6/lib/prest
+export PATH=/usr/lib/postgresql/9.6/bin:$PATH
+```
+
+2) Build the library
+
+```
+./build.bash
+```
+
+## PostgreSQL Config (postgresql.conf)
+
+```
+shared_preload_libraries = 'go_brackground_worker'
 ```

--- a/build.bash
+++ b/build.bash
@@ -1,10 +1,26 @@
 #!/bin/bash
 
-PGROOT="/home/fabrizio/pgsql"
+if [ ! $(which pg_config) ]; then
+	echo "ERROR: pg_config not found"
+	exit 1
+fi
 
+BUILDDIR=".build"
+
+[ -d ${BUILDDIR} ] || mkdir ${BUILDDIR}
+
+INCLUDEDIR=$(pg_config --includedir-server)
+LIBDIR=$(pg_config --pkglibdir)
 LIBNAME="go_background_worker.so"
+LIBOUTPUT="${BUILDDIR}/${LIBNAME}"
 
-export CGO_CFLAGS="-I ${PGROOT}/include/server"
+export CGO_CFLAGS="-I ${INCLUDEDIR}"
 export CGO_LDFLAGS="-shared"
 
-go build -buildmode=c-shared -v -o ${PGROOT}/lib/${LIBNAME}
+echo "Building ${LIBOUTPUT}"
+go build -buildmode=c-shared -o ${LIBOUTPUT}
+
+if [ $? -eq 0 ]; then
+	echo "Sending ${LIBOUTPUT} to ${LIBDIR}"
+	cp -p ${LIBOUTPUT} ${LIBDIR}
+fi

--- a/main_c.c
+++ b/main_c.c
@@ -60,10 +60,17 @@ background_main(Datum main_arg)
 		int rc;
 
 		/* Wait 10s */
+#if (PG_VERSION_NUM >= 100000)
 		rc = WaitLatch(&MyProc->procLatch,
 					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
 					   10000L,
 					   PG_WAIT_EXTENSION);
+#else
+		rc = WaitLatch(&MyProc->procLatch,
+					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+					   10000L);
+#endif
+
 		ResetLatch(&MyProc->procLatch);
 
 		/* Emergency bailout if postmaster has died */


### PR DESCRIPTION
Improve build script using pg_config tool to get output PostgreSQL paths and support PostgreSQL version from 9.4 to 10 according pREST main project.